### PR TITLE
Bump omniauth dependency to 2

### DIFF
--- a/omniauth-ebay-oauth.gemspec
+++ b/omniauth-ebay-oauth.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'omniauth', '~> 1.5'
+  spec.add_dependency 'omniauth', '~> 2.0'
   spec.add_dependency 'omniauth-oauth2', '~> 1.4'
 
   spec.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
Omniauth version 1.9.0 gem has critical advisory and latest version 2.0.1 fixes this. 